### PR TITLE
#12 - Return the errors from the local form.

### DIFF
--- a/app/com/atsid/play/controllers/BaseCrudController.java
+++ b/app/com/atsid/play/controllers/BaseCrudController.java
@@ -709,7 +709,7 @@ public abstract class BaseCrudController<I, T extends Model> extends Controller 
         if (validate == true) {
             Form<T> form = new Form<T>(getBaseModelClass()).bind(Util.toJson(model));
             if (form.hasErrors()) {
-                return new ResultOrValue<T>(CrudResults.validationError(getBaseModelClass(), model));
+                return new ResultOrValue<T>(CrudResults.formError(form);
             }
         }
         return new ResultOrValue<T>(model);

--- a/app/com/atsid/play/controllers/BaseCrudController.java
+++ b/app/com/atsid/play/controllers/BaseCrudController.java
@@ -709,7 +709,7 @@ public abstract class BaseCrudController<I, T extends Model> extends Controller 
         if (validate == true) {
             Form<T> form = new Form<T>(getBaseModelClass()).bind(Util.toJson(model));
             if (form.hasErrors()) {
-                return new ResultOrValue<T>(CrudResults.formError(form);
+                return new ResultOrValue<T>(CrudResults.formError(form));
             }
         }
         return new ResultOrValue<T>(model);

--- a/app/com/atsid/play/controllers/CrudResults.java
+++ b/app/com/atsid/play/controllers/CrudResults.java
@@ -125,8 +125,10 @@ public class CrudResults extends Results {
      * Returns a Result with an error message, and a BAD_REQUEST status
      * @param clazz The model class that wasn't found
      * @param model The model that has the error
+     * @deprecated This is unnecessary, we shouldn't need to re-jsonify a model object to validate it.
      * @return
      */
+    @Deprecated
     public static <T> Result validationError(Class<T> clazz, T model) {
         Form<T> form = new Form<T>(clazz).bind(Json.toJson(model));
         return formError(form);

--- a/test/BaseCrudControllerTest.scala
+++ b/test/BaseCrudControllerTest.scala
@@ -690,7 +690,7 @@ abstract class BaseCrudControllerTest[M <: Model] extends Specification  {
     Step(TestUtils.startApp) ^ fs ^ Step(TestUtils.stopApp)
   }
 
-  private class HttpContextBeforeAfter(script: String) extends ScriptRunnerBeforeAfter(script) {
+  protected class HttpContextBeforeAfter(script: String) extends ScriptRunnerBeforeAfter(script) {
     var mockContext: Http.Context = null;
     var mockBody: Object = null;
 

--- a/test/CrudControllerTest.scala
+++ b/test/CrudControllerTest.scala
@@ -1,9 +1,36 @@
 import com.atsid.play.controllers.CrudController
 import controllers.TestCrudController
 import models.TestModel
+import play.mvc.Result
+import play.test.Helpers._
 
 class CrudControllerTest extends BaseCrudControllerTest[TestModel](classOf[TestModel]) {
   override def getUniqueFieldName(): String =  "randomFieldCrud";
   override def getControllerInstance(): CrudController[TestModel] = new TestCrudController()
   override def getNestedField() = "nestedModel.id";
+
+  "Crud Controller" should {
+
+    /**
+     * The problem was that the validation would show errors for dates, but only if
+     * another property on the model was also failing.  This was because when isModelValid is called, it uses Util.toJson to validate.
+     * This method works OK with our dates, but it would then would call CrudResults.validationError, which would then also call
+     * Form.bindFromRequest, but would call it with Json.toJson, which doesn't serialize dates the same.  Json.toJson uses the Unix Timestamp format
+     * which clashes with the Formats.DateTime("yyyy-mm-dd") on properties.
+     */
+    "not fail validation for dates" in new HttpContextBeforeAfter(testSql)  {
+      val item = new TestModel();
+      item.myTimeStamp = new java.util.Date();
+
+      setRequestBody(item);
+
+      val result: Result = create(getControllerInstance());
+
+      // Shouldn't return a validation error for myTimestamp, since we passed it a legit value
+      contentAsString(result) must not contain("myTimeStamp");
+
+      // This is the only valid error
+      contentAsString(result) must contain("myString");
+    }
+  }
 }

--- a/test/models/TestModel.java
+++ b/test/models/TestModel.java
@@ -4,6 +4,9 @@ import com.atsid.play.models.AbstractBaseModel;
 import com.atsid.play.models.CascadeDelete;
 import com.atsid.play.models.schema.FieldDescription;
 import com.atsid.play.models.schema.FieldType;
+import com.avaje.ebean.annotation.CreatedTimestamp;
+import play.data.format.Formats;
+import play.data.validation.Constraints;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -19,12 +22,16 @@ public class TestModel extends AbstractBaseModel {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     public Long id;
 
+    @Constraints.Required
     public String myString;
 
     public Date myDate;
 
     @FieldDescription(type = FieldType.DATETIME)
     public Date myDateTime;
+
+    @Formats.DateTime(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    public Date myTimeStamp;
 
     public String randomFieldCrud;
 


### PR DESCRIPTION
The local validation uses Util.toJson that may present different results than CrudResults.validationError
